### PR TITLE
support backtick_code_blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ METADATA = ebook/metadata.xml
 TOC = --toc --toc-depth=2 --epub-chapter-level=2 
 COVER_IMAGE = docs/cover.png
 LATEX_CLASS = book
-PANDOC_TEX = pandoc --from="markdown_mmd+link_attributes" $(TOC) --latex-engine=xelatex -V documentclass=book
+PANDOC_TEX = pandoc --from="markdown_mmd+link_attributes+backtick_code_blocks" $(TOC) --latex-engine=xelatex -V documentclass=book
 TEMPLATE=./pdf
 PREFACES =  docs/foreword-trans.md \
 			docs/foreword-v3.md  \

--- a/pdf/template.tex
+++ b/pdf/template.tex
@@ -171,6 +171,7 @@ framexleftmargin=20pt
 
 % below for code syntax highlight
 \usepackage{fancyvrb}
+\VerbatimFootnotes
 %\DefineShortVerb[commandchars=\\\{\}]{\|}
 \DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\},frame=leftline,fontsize=\small}
 % Add ',fontsize=\small' for more characters per line


### PR DESCRIPTION
use \VerbatimFootnotes in template to enable code block in footnotes.