### PR TITLE
Revert "Right aligned in html"

### DIFF
--- a/docs/foreword-trans.md
+++ b/docs/foreword-trans.md
@@ -26,9 +26,9 @@
 
 \   
 
-<!--(pdf)\hfill(pdf)--> <!--(pdf)\iffalse (pdf)--><p align="right"><!--(pdf)\fi (pdf)-->北京 GNU/Linux 用户组（<https://beijinglug.club>）<!--(pdf)\iffalse (pdf)--></p><!--(pdf)\fi(pdf)-->
+<!--(pdf)\hfill(pdf)--> 北京 GNU/Linux 用户组（<https://beijinglug.club>） 
 
-<!--(pdf)\hfill(pdf)--> <!--(pdf)\iffalse (pdf)--><p align="right"><!--(pdf)\fi (pdf)-->2019 年 4 月于北京<!--(pdf)\iffalse (pdf)--></p><!--(pdf)\fi(pdf)-->
+<!--(pdf)\hfill(pdf)--> 2019 年 4 月于北京
 
 [^trans-1]: 相关信息可见 <https://savannah.gnu.org/projects/blug>
 

--- a/docs/foreword-v1.md
+++ b/docs/foreword-v1.md
@@ -46,9 +46,9 @@
 
 \ 
 
-<!--(pdf)\hfill(pdf)--> <!--(pdf)\iffalse (pdf)--><p align="right"><!--(pdf)\fi (pdf)-->劳伦斯·莱斯格[^f1-1]<!--(pdf)\iffalse (pdf)--></p><!--(pdf)\fi(pdf)-->
+<!--(pdf)\hfill(pdf)--> 劳伦斯·莱斯格[^f1-1]
 
-<!--(pdf)\hfill(pdf)--> <!--(pdf)\iffalse (pdf)--><p align="right"><!--(pdf)\fi (pdf)-->LAWRENCE LESSIG<!--(pdf)\iffalse (pdf)--></p><!--(pdf)\fi(pdf)-->
+<!--(pdf)\hfill(pdf)--> LAWRENCE LESSIG
 
 [^f1-1]: 劳伦斯·莱斯格（Lawrence Lessig），是一位美国学者暨学术与政治的行动主义者，哈佛法学院法学教授。他还是知识共享（Creative Commons）发起委员、软件自由法律中心（SFLC）委员、阳光基金会咨询委员与电子前哨基金会（EFF）前任委员。——译者注
 

--- a/docs/foreword-v3.md
+++ b/docs/foreword-v3.md
@@ -20,8 +20,8 @@
 
 \ 
 
-<!--(pdf)\hfill(pdf)--> <!--(pdf)\iffalse (pdf)--><p align="right"><!--(pdf)\fi (pdf)-->雅各·阿贝尔鲍姆[^f3-1]<!--(pdf)\iffalse (pdf)--></p><!--(pdf)\fi(pdf)-->
+<!--(pdf)\hfill(pdf)--> 雅各·阿贝尔鲍姆[^f3-1]
 
-<!--(pdf)\hfill(pdf)--> <!--(pdf)\iffalse (pdf)--><p align="right"><!--(pdf)\fi (pdf)-->JACOB APPELBAUM<!--(pdf)\iffalse (pdf)--></p><!--(pdf)\fi(pdf)-->
+<!--(pdf)\hfill(pdf)--> JACOB APPELBAUM
 
 [^f3-1]: 雅各·阿贝尔鲍姆（Jacob Appelbaum），美国独立记者，计算机安全研究员，艺术家和黑客（Hacker）。受雇于华盛顿大学，曾是 Tor 项目的核心开发者。——译者注

--- a/docs/preface-v3.md
+++ b/docs/preface-v3.md
@@ -20,6 +20,6 @@
 
 \ 
 
-<!--(pdf)\hfill(pdf)--> <!--(pdf)\iffalse (pdf)--><p align="right"><!--(pdf)\fi (pdf)-->理查德·斯托曼<!--(pdf)\iffalse (pdf)--></p><!--(pdf)\fi(pdf)-->
+<!--(pdf)\hfill(pdf)--> 理查德·斯托曼
 
-<!--(pdf)\hfill(pdf)--> <!--(pdf)\iffalse (pdf)--><p align="right"><!--(pdf)\fi (pdf)-->RICHARD STALLMAN<!--(pdf)\iffalse (pdf)--></p><!--(pdf)\fi(pdf)-->
+<!--(pdf)\hfill(pdf)--> RICHARD STALLMAN


### PR DESCRIPTION
我测试的时候发现，PDF 文件的落款整个缺失。先 revert 这个 PR。