### PR TITLE
Use \begin{center} in copyright notice

### DIFF
--- a/pdf/template.tex
+++ b/pdf/template.tex
@@ -351,13 +351,13 @@ copies.
 
 \  
 
-\centering
+\begin{center}
 \fbox{\shortstack[c]{Free Software Foundation\\ 51 Franklin Street, Fifth Floor\\ Boston, MA 02110-1335\\ Copyright © 2002, 2010, 2015 Free Software Foundation, Inc.}}
 
 \  
 
 \noindent{ISBN 978-0-9831592-5-4}
-
+\end{center}
 
 \thispagestyle{empty}
 \setcounter{tocdepth}{1}


### PR DESCRIPTION
原来的会使整本书的文本都居中。