### PR TITLE
Fix building in Pandoc 2.2.1

### DIFF
--- a/docs/foreword-trans.md
+++ b/docs/foreword-trans.md
@@ -26,9 +26,9 @@
 
 \   
 
-<!--(pdf)\hfill(pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->北京 GNU/Linux 用户组（<https://beijinglug.club>）<!-- (pdf)--></p><!--(pdf) -->
+<!--(pdf)\hfill\ (pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->北京 GNU/Linux 用户组（<https://beijinglug.club>）<!-- (pdf)--></p><!--(pdf) -->
 
-<!--(pdf)\hfill(pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->2019 年 4 月于北京<!-- (pdf)--></p><!--(pdf) -->
+<!--(pdf)\hfill\ (pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->2019 年 4 月于北京<!-- (pdf)--></p><!--(pdf) -->
 
 [^trans-1]: 相关信息可见 <https://savannah.gnu.org/projects/blug>
 

--- a/docs/foreword-v1.md
+++ b/docs/foreword-v1.md
@@ -46,9 +46,9 @@
 
 \ 
 
-<!--(pdf)\hfill(pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->劳伦斯·莱斯格[^f1-1]<!-- (pdf)--></p><!--(pdf) -->
+<!--(pdf)\hfill\ pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->劳伦斯·莱斯格[^f1-1]<!-- (pdf)--></p><!--(pdf) -->
 
-<!--(pdf)\hfill(pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->LAWRENCE LESSIG<!-- (pdf)--></p><!--(pdf) -->
+<!--(pdf)\hfill\ (pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->LAWRENCE LESSIG<!-- (pdf)--></p><!--(pdf) -->
 
 [^f1-1]: 劳伦斯·莱斯格（Lawrence Lessig），是一位美国学者暨学术与政治的行动主义者，哈佛法学院法学教授。他还是知识共享（Creative Commons）发起委员、软件自由法律中心（SFLC）委员、阳光基金会咨询委员与电子前哨基金会（EFF）前任委员。——译者注
 

--- a/docs/foreword-v3.md
+++ b/docs/foreword-v3.md
@@ -20,8 +20,8 @@
 
 \ 
 
-<!--(pdf)\hfill(pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->雅各·阿贝尔鲍姆[^f3-1]<!-- (pdf)--></p><!--(pdf) -->
+<!--(pdf)\hfill\ (pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->雅各·阿贝尔鲍姆[^f3-1]<!-- (pdf)--></p><!--(pdf) -->
 
-<!--(pdf)\hfill(pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->JACOB APPELBAUM<!-- (pdf)--></p><!--(pdf) -->
+<!--(pdf)\hfill\ (pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->JACOB APPELBAUM<!-- (pdf)--></p><!--(pdf) -->
 
 [^f3-1]: 雅各·阿贝尔鲍姆（Jacob Appelbaum），美国独立记者，计算机安全研究员，艺术家和黑客（Hacker）。受雇于华盛顿大学，曾是 Tor 项目的核心开发者。——译者注

--- a/docs/preface-v3.md
+++ b/docs/preface-v3.md
@@ -20,6 +20,6 @@
 
 \ 
 
-<!--(pdf)\hfill(pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->理查德·斯托曼<!-- (pdf)--></p><!--(pdf) -->
+<!--(pdf)\hfill\ (pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->理查德·斯托曼<!-- (pdf)--></p><!--(pdf) -->
 
-<!--(pdf)\hfill(pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->RICHARD STALLMAN<!-- (pdf)--></p><!--(pdf) -->
+<!--(pdf)\hfill\ (pdf)--> <!-- (pdf)--><p align="right"><!--(pdf) -->RICHARD STALLMAN<!-- (pdf)--></p><!--(pdf) -->


### PR DESCRIPTION
原来的版本用 Pandoc 2.2.1 生成的 pdf 中有“\<p align="right"\>”字样……